### PR TITLE
Use update instead of add

### DIFF
--- a/paypro-gateways-woocommerce/includes/paypro/wc/woocommerce.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/woocommerce.php
@@ -29,11 +29,11 @@ class PayPro_WC_Woocommerce
     }
 
     /**
-     * Sets a payment hash for an order id
+     * Sets or updates the payment hash for an order id
      */
     public function setOrderPaymentHash($order_id, $payment_hash)
     {
-        add_post_meta($order_id, $this->post_data_key, $payment_hash, true);
+        update_post_meta($order_id, $this->post_data_key, $payment_hash, true);
     }
 
     /**


### PR DESCRIPTION
Als er meerdere payments worden aangemaakt voor dezelfde order zal de payment_hash niet goed geupdate worden. Door update_post_meta te gebruiken wordt de payment_hash geupdate of aangemaakt als deze er nog niet is.