### PR TITLE
Check all payment_hashes now

### DIFF
--- a/paypro-gateways-woocommerce/includes/paypro/wc/api.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/api.php
@@ -87,21 +87,19 @@ class PayPro_WC_Api
     }
 
     /**
-     * Determines what the order status should be based on the payment statuses.
-     * Returns open, completed or cancelled.
+     * Determines what the order status should be, based on the payment statuses
+     * Returns an array with the status and the payment_hash
      */
     private function determineSaleStatus($sale_statuses)
     {
         foreach($sale_statuses as $sale)
         {
-            if($sale['status'] != 'open' && $sale['status'] != 'cancelled')
+            if($sale['status'] != 'open')
                 return array('hash' => $sale['hash'], 'status' => 'completed');
-            elseif($sale['status'] == 'open')
-                $result = $sale;
-            elseif($sale['status'] == 'cancelled' && !$result)
+            else
                 $result = $sale;
         }
 
-        return empty($result) ? 'open' : $result;
+        return empty($result) ? array('status' => 'open', 'hash' => 'unknown') : $result;
     }
 }

--- a/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
@@ -67,13 +67,13 @@ class PayPro_WC_Plugin
         // Only handle order if it is still pending
         if(self::$woocommerce->hasOrderStatus($order, 'pending'))
         {
-            $payment_hash = self::$wc_api->getPaymentHashFromOrder($order);
-            $payment_status = self::$wc_api->getSaleStatusFromPaymentHash($payment_hash);
+            $payment_hashes = self::$wc_api->getPaymentHashesFromOrder($order);
+            $sale = self::$wc_api->getSaleStatusFromPaymentHashes($payment_hashes);
 
             // Check status and do appropiate response
-            if(strcasecmp($payment_status, 'cancelled') === 0)
+            if(strcasecmp($sale['status'], 'cancelled') === 0)
             {
-                self::$woocommerce->cancelOrder($order, $payment_hash);
+                self::$woocommerce->cancelOrder($order, $sale['hash']);
                 self::debug(__CLASS__ . ': OnReturn - Payment cancelled for order: ' . $order->id);
 
                 wp_safe_redirect($order->get_cancel_order_url());
@@ -81,14 +81,14 @@ class PayPro_WC_Plugin
             } 
             else
             {
-                if(strcasecmp($payment_status, 'open') !== 0)
+                if(strcasecmp($sale['status'], 'open') !== 0)
                 {
-                    self::$woocommerce->completeOrder($order, $payment_hash);
+                    self::$woocommerce->completeOrder($order, $sale['hash']);
                     self::debug(__CLASS__ . ': OnReturn - Payment completed for order: ' . $order->id);
                 }
                 else
                 {
-                    $order->add_order_note(__('PayPro payment pending (' .  $payment_hash . ')'));
+                    $order->add_order_note(__('PayPro payment pending (' .  $sale['hash'] . ')'));
                     self::debug(__CLASS__ . ': OnReturn - Payment still open for order: ' . $order->id);
                 }
 

--- a/paypro-gateways-woocommerce/includes/paypro/wc/woocommerce.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/woocommerce.php
@@ -29,27 +29,27 @@ class PayPro_WC_Woocommerce
     }
 
     /**
-     * Sets or updates the payment hash for an order id
+     * Adds a payment hashes to the order post meta
      */
-    public function setOrderPaymentHash($order_id, $payment_hash)
+    public function addOrderPaymentHash($order_id, $payment_hash)
     {
-        update_post_meta($order_id, $this->post_data_key, $payment_hash, true);
+        add_post_meta($order_id, $this->post_data_key, $payment_hash, false);
     }
 
     /**
-     * Gets a payment hash by order id
+     * Gets all payment hashes for an order from the post meta
      */
-    public function getOrderPaymentHash($order_id)
+    public function getOrderPaymentHashes($order_id)
     {
-        return get_post_meta($order_id, $this->post_data_key, true);
+        return get_post_meta($order_id, $this->post_data_key, false);
     }
 
     /**
-     * Removes an order id from the post meta
+     * Removes all payments hashes for an order from the post meta
      */
-    public function removeOrderPaymentHash($order_id)
+    public function removeOrderPaymentHashes($order_id)
     {
-        delete_post_meta($order_id, $this->post_data_key, true);
+        delete_post_meta($order_id, $this->post_data_key);
     }
 
     /**
@@ -74,6 +74,6 @@ class PayPro_WC_Woocommerce
         $order->reduce_order_stock();
         $order->payment_complete();
 
-        $this->removeOrderPaymentHash($order->id);
+        $this->removeOrderPaymentHashes($order->id);
     }
 }


### PR DESCRIPTION
Dit zou de status updates in WooCommerce moeten fixen als er meerdere payments aangemaakt zijn. We slaan nu alle payment hashes op en bij callbacks worden alle payment hashes gechecked op hun status. 