### PR TITLE
Fix bug where product id would not be sent.

### DIFF
--- a/paypro-gateways-woocommerce/includes/paypro/wc/gateway/abstract.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/gateway/abstract.php
@@ -129,7 +129,7 @@ abstract class PayPro_WC_Gateway_Abstract extends WC_Payment_Gateway
 
         // Add product_id if the setting is set
         if(is_int($product_id) && $product_id > 0)
-            $data['product_id'] = intval($product_id);
+            $data['product_id'] = $product_id;
 
         // Call PayPro API to create a payment
         $result = PayPro_WC_Plugin::$paypro_api->createPayment($data);

--- a/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
@@ -4,7 +4,7 @@ class PayPro_WC_Plugin
 {
     const PLUGIN_ID = 'paypro-gateways-woocommerce';
     const PLUGIN_TITLE = 'PayPro Gateways - WooCommerce';
-    const PLUGIN_VERSION = '1.2.2';
+    const PLUGIN_VERSION = '1.2.3';
 
     public static $paypro_gateways = array(
         'PayPro_WC_Gateway_Ideal',

--- a/paypro-gateways-woocommerce/includes/paypro/wc/settings.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/settings.php
@@ -31,7 +31,7 @@ class PayPro_WC_Settings
      */
     public function productId()
     {
-        return trim(get_option(PayPro_WC_Plugin::getSettingId('product-id')));
+        return intval(trim(get_option(PayPro_WC_Plugin::getSettingId('product-id'))));
     }
 
     /**

--- a/paypro-gateways-woocommerce/paypro-gateways-woocommerce.php
+++ b/paypro-gateways-woocommerce/paypro-gateways-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: PayPro Gateways - WooCommerce
  * Plugin URI: https://www.paypro.nl/
  * Description: With this plugin you easily add all PayPro payment gateways to your WooCommerce webshop.
- * Version: 1.2.2
+ * Version: 1.2.3
  * Author: PayPro
  * Author URI: https://www.paypro.nl/
  * Text Domain: paypro-gateways-woocommerce


### PR DESCRIPTION
Product ID is not an int when you get the setting from `PayPro_WC_Plugin::$settings->productId()`.

This means the check at line 132 will always fail.

Edit `productId()` to always return an `int`.