### PR TITLE
Fix order_key sanitize

### DIFF
--- a/paypro-gateways-woocommerce/includes/paypro/wc/api.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/api.php
@@ -16,7 +16,7 @@ class PayPro_WC_Api
         }
 
         $order_id = intval($_GET['order_id']);
-        $order_key = sanitize_key($_GET['order_key']);
+        $order_key = preg_replace('/[^A-Za-z0-9_]/', '', $_GET['order_key']);
 
         // Check if order_id is a known order
         $order = PayPro_WC_Plugin::$woocommerce->getOrder($order_id);

--- a/paypro-gateways-woocommerce/includes/paypro/wc/api.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/api.php
@@ -16,7 +16,7 @@ class PayPro_WC_Api
         }
 
         $order_id = intval($_GET['order_id']);
-        $order_key = preg_replace('/[^A-Za-z0-9_]/', '', $_GET['order_key']);
+        $order_key = sanitize_text_field($_GET['order_key']);
 
         // Check if order_id is a known order
         $order = PayPro_WC_Plugin::$woocommerce->getOrder($order_id);

--- a/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
@@ -4,7 +4,7 @@ class PayPro_WC_Plugin
 {
     const PLUGIN_ID = 'paypro-gateways-woocommerce';
     const PLUGIN_TITLE = 'PayPro Gateways - WooCommerce';
-    const PLUGIN_VERSION = '1.3.1';
+    const PLUGIN_VERSION = '1.3.2';
 
     public static $paypro_gateways = array(
         'PayPro_WC_Gateway_Ideal',

--- a/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
@@ -4,7 +4,7 @@ class PayPro_WC_Plugin
 {
     const PLUGIN_ID = 'paypro-gateways-woocommerce';
     const PLUGIN_TITLE = 'PayPro Gateways - WooCommerce';
-    const PLUGIN_VERSION = '1.3.0';
+    const PLUGIN_VERSION = '1.3.1';
 
     public static $paypro_gateways = array(
         'PayPro_WC_Gateway_Ideal',

--- a/paypro-gateways-woocommerce/paypro-gateways-woocommerce.php
+++ b/paypro-gateways-woocommerce/paypro-gateways-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: PayPro Gateways - WooCommerce
  * Plugin URI: https://www.paypro.nl/
  * Description: With this plugin you easily add all PayPro payment gateways to your WooCommerce webshop.
- * Version: 1.3.0
+ * Version: 1.3.1
  * Author: PayPro
  * Author URI: https://www.paypro.nl/
  * Text Domain: paypro-gateways-woocommerce

--- a/paypro-gateways-woocommerce/paypro-gateways-woocommerce.php
+++ b/paypro-gateways-woocommerce/paypro-gateways-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: PayPro Gateways - WooCommerce
  * Plugin URI: https://www.paypro.nl/
  * Description: With this plugin you easily add all PayPro payment gateways to your WooCommerce webshop.
- * Version: 1.3.1
+ * Version: 1.3.2
  * Author: PayPro
  * Author URI: https://www.paypro.nl/
  * Text Domain: paypro-gateways-woocommerce


### PR DESCRIPTION
WooCommerce genereert de `order_key` nu anders, waardoor deze ook hoofdletters kan bevatten. Terugkeren naar de webshop werkt daardoor niet meer. Zie https://github.com/woocommerce/woocommerce/blob/master/includes/wc-order-functions.php#L158.