### PR TITLE
Add VAT percentage settings

### DIFF
--- a/paypro-gateways-woocommerce/assets/js/paypro-gateways-woocommerce.js
+++ b/paypro-gateways-woocommerce/assets/js/paypro-gateways-woocommerce.js
@@ -1,0 +1,16 @@
+(function($) {
+    $(document).ready(function() {
+        var vat_percentage_fixed_container = $('input#paypro-gateways-woocommerce_vat-percentage-fixed').parents('tr');
+        var vat_percentage_setting_select = $('select#paypro-gateways-woocommerce_vat-percentage-setting');
+
+        vat_percentage_setting_select.change(function() {
+            if ($(this).val() == 'fixed') {
+                vat_percentage_fixed_container.show();
+            } else {
+                vat_percentage_fixed_container.hide();
+            }
+        });
+
+        vat_percentage_setting_select.change();
+    });
+})(jQuery);

--- a/paypro-gateways-woocommerce/includes/paypro/wc/gateway/abstract.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/gateway/abstract.php
@@ -112,6 +112,7 @@ abstract class PayPro_WC_Gateway_Abstract extends WC_Payment_Gateway
         $shippingCity = PayPro_WC_Plugin::$woocommerce->getShippingCity($order);
         $shippingCountry = PayPro_WC_Plugin::$woocommerce->getShippingCountry($order);
         $shippingPostcode = PayPro_WC_Plugin::$woocommerce->getShippingPostcode($order);
+        $vatPercentage = PayPro_WC_Plugin::$woocommerce->getVatPercentage($order);
 
         // Set the order variables for PayPro
         $data = array(
@@ -132,7 +133,8 @@ abstract class PayPro_WC_Gateway_Abstract extends WC_Payment_Gateway
             'shipping_address'  => $shippingAddress,
             'shipping_postal'   => $shippingPostcode,
             'shipping_city'     => $shippingCity,
-            'shipping_country'  => $shippingCountry
+            'shipping_country'  => $shippingCountry,
+            'vat'               => $vatPercentage
         );
 
         // Add product_id if the setting is set

--- a/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
@@ -4,7 +4,7 @@ class PayPro_WC_Plugin
 {
     const PLUGIN_ID = 'paypro-gateways-woocommerce';
     const PLUGIN_TITLE = 'PayPro Gateways - WooCommerce';
-    const PLUGIN_VERSION = '1.3.2';
+    const PLUGIN_VERSION = '1.3.3';
 
     public static $paypro_gateways = array(
         'PayPro_WC_Gateway_Ideal',

--- a/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
@@ -4,7 +4,7 @@ class PayPro_WC_Plugin
 {
     const PLUGIN_ID = 'paypro-gateways-woocommerce';
     const PLUGIN_TITLE = 'PayPro Gateways - WooCommerce';
-    const PLUGIN_VERSION = '1.3.3';
+    const PLUGIN_VERSION = '1.4.0';
 
     public static $paypro_gateways = array(
         'PayPro_WC_Gateway_Ideal',

--- a/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
@@ -157,20 +157,14 @@ class PayPro_WC_Plugin
                 'id'         => self::getSettingId('payment-description'),
                 'title'      => __('Description', 'paypro-gateways-woocommerce'),
                 'type'       => 'text',
-                'desc_tip'   => __('Payment description send to PayPro.', 'paypro-gateways-woocommerce'),
+                'desc_tip'   => __('Payment description sent to PayPro.', 'paypro-gateways-woocommerce'),
                 'css'        => 'width: 350px',
             ),
             array(
                 'id'         => self::getSettingId('vat-percentage-dynamic'),
                 'title'      => __('Dynamic VAT percentage', 'paypro-gateways-woocommerce'),
                 'type'       => 'checkbox',
-                'desc_tip'   => __(
-                    '
-                        When enabled, the VAT percentage inside PayPro will be based on the highest VAT percentage used in the order.
-                        When disabled, the VAT percentage inside PayPro will be based on the VAT percentage of the PayPro Product ID (if provided) or the merchant details.
-                    ',
-                    'paypro-gateways-woocommerce'
-                )
+                'desc_tip'   => __('Post the highest VAT percentage from the order to PayPro. When disabled, the VAT percentage of the PayPro product (if provided) or the merchant will be used.', 'paypro-gateways-woocommerce')
             ),
             array(
                 'id'         => self::getSettingId('payment-complete-status'),

--- a/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
@@ -37,14 +37,12 @@ class PayPro_WC_Plugin
 
         // Add filters and actions
         add_filter('woocommerce_payment_gateways_settings',   array(__CLASS__, 'addSettingsFields'));
-
         add_filter('woocommerce_payment_gateways',            array(__CLASS__, 'addGateways'));
 
         add_action('woocommerce_api_paypro_return',           array(__CLASS__, 'onReturn'));
-
         add_action('woocommerce_api_paypro_cancel',           array(__CLASS__, 'onCancel'));
-
         add_action('admin_notices',                           array(__CLASS__, 'addApiKeyReminder'));
+        add_action('admin_enqueue_scripts',                   array(__CLASS__, 'adminEnqueueScripts'));
 
         // Initialize all PayPro classes we need
         self::$settings = new PayPro_WC_Settings();
@@ -161,10 +159,21 @@ class PayPro_WC_Plugin
                 'css'        => 'width: 350px',
             ),
             array(
-                'id'         => self::getSettingId('vat-percentage-dynamic'),
-                'title'      => __('Dynamic VAT percentage', 'paypro-gateways-woocommerce'),
-                'type'       => 'checkbox',
-                'desc_tip'   => __('Post the highest VAT percentage from the order to PayPro. When disabled, the VAT percentage of the PayPro product (if provided) or the merchant will be used.', 'paypro-gateways-woocommerce')
+                'id'         => self::getSettingId('vat-percentage-setting'),
+                'title'      => __('VAT percentage to use in PayPro', 'paypro-gateways-woocommerce'),
+                'type'       => 'select',
+                'options'    => array(
+                    'default' => __('Let PayPro decide (default)', 'paypro-gateways-woocommerce'),
+                    'fixed' => __('Fixed value', 'paypro-gateways-woocommerce'),
+                    'highest_in_order' => __('Use highest used VAT percentage from order', 'paypro-gateways-woocommerce'),
+                ),
+                'desc_tip'   => __('How to handle the VAT percentage posted to PayPro', 'paypro-gateways-woocommerce')
+            ),
+            array(
+                'id'         => self::getSettingId('vat-percentage-fixed'),
+                'title'      => __('Fixed VAT percentage value', 'paypro-gateways-woocommerce'),
+                'type'       => 'text',
+                'desc_tip'   => __('Fixed VAT percentage to post to PayPro', 'paypro-gateways-woocommerce')
             ),
             array(
                 'id'         => self::getSettingId('payment-complete-status'),
@@ -287,5 +296,10 @@ class PayPro_WC_Plugin
                     'paypro-gateways-woocommerce')
             );
         }
+    }
+
+    public static function adminEnqueueScripts()
+    {
+        wp_enqueue_script(self::PLUGIN_ID, plugins_url(self::PLUGIN_ID . '/assets/js/' . self::PLUGIN_ID . '.js'));
     }
 }

--- a/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/plugin.php
@@ -161,6 +161,18 @@ class PayPro_WC_Plugin
                 'css'        => 'width: 350px',
             ),
             array(
+                'id'         => self::getSettingId('vat-percentage-dynamic'),
+                'title'      => __('Dynamic VAT percentage', 'paypro-gateways-woocommerce'),
+                'type'       => 'checkbox',
+                'desc_tip'   => __(
+                    '
+                        When enabled, the VAT percentage inside PayPro will be based on the highest VAT percentage used in the order.
+                        When disabled, the VAT percentage inside PayPro will be based on the VAT percentage of the PayPro Product ID (if provided) or the merchant details.
+                    ',
+                    'paypro-gateways-woocommerce'
+                )
+            ),
+            array(
                 'id'         => self::getSettingId('payment-complete-status'),
                 'title'      => __('Payment Complete Status', 'paypro-gateways-woocommerce'),
                 'type'       => 'select',

--- a/paypro-gateways-woocommerce/includes/paypro/wc/settings.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/settings.php
@@ -59,10 +59,22 @@ class PayPro_WC_Settings
     }
 
     /**
-     * Returns the vat percentage dynamic setting
+     * Returns the vat percentage setting
      */
-    public function vatPercentageDynamic()
+    public function vatPercentageSetting()
     {
-        return trim(get_option(PayPro_WC_Plugin::getSettingId('vat-percentage-dynamic'))) === 'yes';
+        return trim(get_option(PayPro_WC_Plugin::getSettingId('vat-percentage-setting')));
+    }
+
+    /**
+     * Returns the vat percentage fixed value
+     */
+    public function vatPercentageFixedValue()
+    {
+        if ($this->vatPercentageSetting() == 'fixed') {
+            return trim(get_option(PayPro_WC_Plugin::getSettingId('vat-percentage-fixed')));
+        } else {
+            return null;
+        }
     }
 }

--- a/paypro-gateways-woocommerce/includes/paypro/wc/settings.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/settings.php
@@ -57,4 +57,12 @@ class PayPro_WC_Settings
     {
         return trim(get_option(PayPro_WC_Plugin::getSettingId('payment-complete-status')));
     }
+
+    /**
+     * Returns the vat percentage dynamic setting
+     */
+    public function vatPercentageDynamic()
+    {
+        return trim(get_option(PayPro_WC_Plugin::getSettingId('vat-percentage-dynamic'))) === 'yes';
+    }
 }

--- a/paypro-gateways-woocommerce/includes/paypro/wc/woocommerce.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/woocommerce.php
@@ -278,7 +278,7 @@ class PayPro_WC_Woocommerce
      */
     public function getVatPercentage($order)
     {
-        if (is_a($order, 'WC_Order')) {
+        if (PayPro_WC_Plugin::$settings->vatPercentageDynamic() && is_a($order, 'WC_Order')) {
             $order_rate_percentages = array_map(
                 function( $order_item ) {
                     return $order_item->get_rate_percent();

--- a/paypro-gateways-woocommerce/includes/paypro/wc/woocommerce.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/woocommerce.php
@@ -272,4 +272,23 @@ class PayPro_WC_Woocommerce
 
         return $email;
     }
+
+    /**
+     * Gets the vat percentage of the order
+     */
+    public function getVatPercentage($order)
+    {
+        if (is_a($order, 'WC_Order')) {
+            $order_rate_percentages = array_map(
+                function( $order_item ) {
+                    return $order_item->get_rate_percent();
+                },
+                $order->get_items( 'tax' )
+            );
+
+            return max($order_rate_percentages);
+        } else {
+            return null;
+        }
+    }
 }

--- a/paypro-gateways-woocommerce/includes/paypro/wc/woocommerce.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/woocommerce.php
@@ -278,7 +278,13 @@ class PayPro_WC_Woocommerce
      */
     public function getVatPercentage($order)
     {
-        if (PayPro_WC_Plugin::$settings->vatPercentageDynamic() && is_a($order, 'WC_Order')) {
+        $vatPercentageSetting = PayPro_WC_Plugin::$settings->vatPercentageSetting();
+
+        if (!is_a($order, 'WC_Order')) {
+            return null;
+        } elseif ($vatPercentageSetting == 'fixed' && is_numeric(PayPro_WC_Plugin::$settings->vatPercentageFixedValue())) {
+            return PayPro_WC_Plugin::$settings->vatPercentageFixedValue();
+        } elseif ($vatPercentageSetting == 'highest_in_order') {
             $order_rate_percentages = array_map(
                 function( $order_item ) {
                     return $order_item->get_rate_percent();

--- a/paypro-gateways-woocommerce/includes/paypro/wc/woocommerce.php
+++ b/paypro-gateways-woocommerce/includes/paypro/wc/woocommerce.php
@@ -278,13 +278,13 @@ class PayPro_WC_Woocommerce
      */
     public function getVatPercentage($order)
     {
-        $vatPercentageSetting = PayPro_WC_Plugin::$settings->vatPercentageSetting();
+        $vat_percentage_setting = PayPro_WC_Plugin::$settings->vatPercentageSetting();
 
         if (!is_a($order, 'WC_Order')) {
             return null;
-        } elseif ($vatPercentageSetting == 'fixed' && is_numeric(PayPro_WC_Plugin::$settings->vatPercentageFixedValue())) {
+        } elseif ($vat_percentage_setting == 'fixed' && is_numeric(PayPro_WC_Plugin::$settings->vatPercentageFixedValue())) {
             return PayPro_WC_Plugin::$settings->vatPercentageFixedValue();
-        } elseif ($vatPercentageSetting == 'highest_in_order') {
+        } elseif ($vat_percentage_setting == 'highest_in_order') {
             $order_rate_percentages = array_map(
                 function( $order_item ) {
                     return $order_item->get_rate_percent();

--- a/paypro-gateways-woocommerce/paypro-gateways-woocommerce.php
+++ b/paypro-gateways-woocommerce/paypro-gateways-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: PayPro Gateways - WooCommerce
  * Plugin URI: https://www.paypro.nl/
  * Description: With this plugin you easily add all PayPro payment gateways to your WooCommerce webshop.
- * Version: 1.3.2
+ * Version: 1.3.3
  * Author: PayPro
  * Author URI: https://www.paypro.nl/
  * Text Domain: paypro-gateways-woocommerce

--- a/paypro-gateways-woocommerce/paypro-gateways-woocommerce.php
+++ b/paypro-gateways-woocommerce/paypro-gateways-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: PayPro Gateways - WooCommerce
  * Plugin URI: https://www.paypro.nl/
  * Description: With this plugin you easily add all PayPro payment gateways to your WooCommerce webshop.
- * Version: 1.3.3
+ * Version: 1.4.0
  * Author: PayPro
  * Author URI: https://www.paypro.nl/
  * Text Domain: paypro-gateways-woocommerce


### PR DESCRIPTION
Currently our WooCommerce plugin does not post VAT percentages so the value is always fixed. This PR adds 3 options for the VAT percentage changeable in the plugin settings:

* default behaviour (let PayPro 'decide')
* dynamically pick the highest `order_item`'s VAT percentage
* a fixed value

Fixed https://app.intercom.io/a/apps/mpb7huub/conversations/23450820394?redirectTo=feed.