### PR TITLE
added settings link

### DIFF
--- a/paypro-gateways-woocommerce/paypro-gateways-woocommerce.php
+++ b/paypro-gateways-woocommerce/paypro-gateways-woocommerce.php
@@ -28,7 +28,19 @@ function paypro_plugin_init()
     {
         PayPro_WC_Autoload::register();
         PayPro_WC_Plugin::init();
+        // add links that requires woocommerce to be active
+        add_filter('plugin_action_links_' . plugin_basename(__FILE__), 'paypro_plugin_wc_action_links');
     }
+}
+
+/**
+ * Add action links to paypro plugin 
+ */
+function paypro_plugin_wc_action_links($links) {
+    $paypro_links = array(
+        '<a href="'.admin_url('admin.php?page=wc-settings&tab=checkout').'"> Settings </a>'
+        );
+    return array_merge($paypro_links, $links);
 }
 
 /**


### PR DESCRIPTION
based on : #48 

Added a settings links if woocommerce is activated so its easier to go to the settings once activated

## preview
if woocommerce is active
![image](https://user-images.githubusercontent.com/55430516/146002402-bee06b78-ac28-44e1-a4f1-a3574d3c78d3.png)

if woocommerce is not active (also before)
![image](https://user-images.githubusercontent.com/55430516/146002515-deb3aca5-8bdc-4e42-bcc8-05a8469ef81b.png)
