### PR TITLE
Change callback body to ok

### DIFF
--- a/includes/paypro/wc/gateway/abstract.php
+++ b/includes/paypro/wc/gateway/abstract.php
@@ -218,6 +218,10 @@ abstract class PayPro_WC_Gateway_Abstract extends WC_Payment_Gateway
         }
 
         PayPro_WC_Plugin::debug($this->id . ': Callback - Order is not pending, so leaving it alone');
+
+        header( 'HTTP/1.1 200 OK' );
+            echo 'ok';
+            die();
     }
 
     /**

--- a/includes/paypro/wc/gateway/abstract.php
+++ b/includes/paypro/wc/gateway/abstract.php
@@ -219,9 +219,9 @@ abstract class PayPro_WC_Gateway_Abstract extends WC_Payment_Gateway
 
         PayPro_WC_Plugin::debug($this->id . ': Callback - Order is not pending, so leaving it alone');
 
-        header( 'HTTP/1.1 200 OK' );
-            echo 'ok';
-            die();
+        status_header(200);
+        echo 'ok';
+        die();
     }
 
     /**

--- a/resources/readme.txt
+++ b/resources/readme.txt
@@ -92,6 +92,7 @@ You can find your product id at 'Webshop Koppelen' in the PayPro dashboard.
 = 2.0.1 =
 
 * Fixed a bug where order would not be automatically cancelled when payment is cancelled
+* Return 'ok' in the callback response body
 
 = 2.0.0 =
 


### PR DESCRIPTION
Our server receives postbacks with `-1` in the body, which is standard for WooCommerce. 
The `ok` should be returned in the response body, otherwise 'not successful postback' email can be triggered.