### PR TITLE
Make icons on old checkout more consistent

### DIFF
--- a/assets/styles/paypro-checkout.css
+++ b/assets/styles/paypro-checkout.css
@@ -1,0 +1,3 @@
+#payment .payment_methods li img {
+  max-width: 40px;
+}

--- a/assets/styles/paypro-checkout.css
+++ b/assets/styles/paypro-checkout.css
@@ -1,3 +1,3 @@
-#payment .payment_methods li img {
+.woocommerce-checkout #payment .payment_methods li img {
   max-width: 40px;
 }

--- a/includes/paypro/wc/gateway/abstract.php
+++ b/includes/paypro/wc/gateway/abstract.php
@@ -33,6 +33,7 @@ abstract class PayPro_WC_Gateway_Abstract extends WC_Payment_Gateway
 
         add_action('woocommerce_api_' . $this->id, array($this, 'callback'));
         add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'process_admin_options'));
+        add_action('wp_enqueue_scripts', array($this, 'addCheckoutStyles'));
 
         if(!$this->isValid())
             $this->enabled = 'no';
@@ -222,6 +223,20 @@ abstract class PayPro_WC_Gateway_Abstract extends WC_Payment_Gateway
         status_header(200);
         echo 'ok';
         die();
+    }
+
+    /**
+     * Adds the checkout styles to the checkout page
+     */
+    public function addCheckoutStyles() {
+        wp_register_style(
+            'paypro-checkout',
+            PAYPRO_WC_PLUGIN_URL . 'assets/styles/paypro-checkout.css',
+            [],
+            PAYPRO_WC_VERSION
+        );
+
+        wp_enqueue_style('paypro-checkout');
     }
 
     /**

--- a/paypro-gateways-woocommerce.php
+++ b/paypro-gateways-woocommerce.php
@@ -19,6 +19,7 @@
 define('PAYPRO_WC_PLUGIN_FILE', __FILE__);
 define('PAYPRO_WC_PLUGIN_PATH', plugin_dir_path(PAYPRO_WC_PLUGIN_FILE));
 define('PAYPRO_WC_PLUGIN_URL', plugin_dir_url(PAYPRO_WC_PLUGIN_FILE));
+define('PAYPRO_WC_VERSION', '2.0.1');
 
 require_once('vendor/autoload.php');
 require_once('includes/paypro/wc/autoload.php');

--- a/tasks/docker-setup.mjs
+++ b/tasks/docker-setup.mjs
@@ -15,7 +15,7 @@ const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
 function dr(command) {
   const args = Array.isArray(command) ? command : command.split(' ');
-  return $`docker run -it --env-file default.env --rm --user xfs --volumes-from ${WP_CONTAINER} --network container:${WP_CONTAINER} wordpress:cli ${args}`;
+  return $`docker run -it --env-file default.env --rm --user 33:33 --volumes-from ${WP_CONTAINER} --network container:${WP_CONTAINER} wordpress:cli ${args}`;
 }
 
 result = await dr('wp db check --path=/var/www/html').exitCode;


### PR DESCRIPTION
There is currently an issue where the icons are too large on the old checkout form. This is caused by some styles not applying widths on the icons and our icons being rather large.

Before:

![image](https://github.com/paypronl/woocommerce-payments-plugin/assets/13639105/100d4494-45e0-4ac3-a05b-43de870e1192)

After

![image](https://github.com/paypronl/woocommerce-payments-plugin/assets/13639105/08419147-1d6f-4da4-bbcd-fcb9a6623b88)

This PR also changes the user in the docker script to 33:33 to be more consistent.
