### PR TITLE
Add webhook to settings

### DIFF
--- a/includes/paypro/api/PayProApiHelper.php
+++ b/includes/paypro/api/PayProApiHelper.php
@@ -15,6 +15,22 @@ class PayProApiHelper
         $this->testMode = $testMode ? true : false;
     }
 
+    public function getWebhook($reference) {
+        return $this->api->webhooks->get($reference);
+    }
+
+    public function createWebhook() {
+        $webhook_url = WC()->api_request_url('paypro_wc_plugin');
+
+        return $this->api->webhooks->create(
+            [
+                'name' => 'WooCommerce',
+                'description' => 'WooCommerce webhook',
+                'url' => $webhook_url
+            ]
+        );
+    }
+
     public function getIdealIssuers()
     {
         $result = $this->api->payMethods->list();

--- a/includes/paypro/wc/plugin.php
+++ b/includes/paypro/wc/plugin.php
@@ -59,7 +59,7 @@ class PayPro_WC_Plugin
         self::$woocommerce = new PayPro_WC_Woocommerce();
         self::$wc_api = new PayPro_WC_Api();
         self::$paypro_api = new PayProApiHelper();
-        self::$paypro_api->init(self::$settings->apiKey(), self::$settings->testMode());
+        self::$paypro_api->init(self::$settings->apiKey());
 
         self::setupGateways();
 

--- a/includes/paypro/wc/settings.php
+++ b/includes/paypro/wc/settings.php
@@ -9,14 +9,6 @@ class PayPro_WC_Settings
     }
 
     /**
-     * Returns if plugin is in test mode
-     */
-    public function testMode()
-    {
-        return trim(get_option(self::getId('test-mode'))) === 'yes';
-    }
-
-    /**
      * Returns if plugin is in debug mode
      */
     public function debugMode()

--- a/includes/paypro/wc/settingspage.php
+++ b/includes/paypro/wc/settingspage.php
@@ -22,21 +22,22 @@ class PayPro_WC_Settingspage extends WC_Settings_Page
             $hide_save_button = true;
 
             try {
-              $webhook_id = get_option('paypro_webhook_id', true);
+                $webhook_id = get_option('paypro-webhook-id', true);
 
-              $webhook = PayPro_WC_Plugin::$paypro_api->getWebhook($webhook_id);
+                $webhook = PayPro_WC_Plugin::$paypro_api->getWebhook($webhook_id);
 
-              echo '<table>
-                      <tr>
-                        <td><strong>Webhook ID</strong></td>
-                        <td style="padding: 5px 15px"><code>' . $webhook->id . '</code></td>
-                      </tr>
-                      <tr>
-                        <td><strong>Webhook Name</strong></td>
-                        <td style="padding: 5px 15px">' . $webhook->name . '</td>
-                      </tr>
-                    </table>';
-            } catch(\PayPro\Exception\ApiErrorException $e) {
+                echo '<table>
+                        <tr>
+                          <td><strong>Webhook ID</strong></td>
+                          <td style="padding: 5px 15px"><code>' . $webhook?->id . '</code></td>
+                        </tr>
+                        <tr>
+                          <td><strong>Webhook Name</strong></td>
+                          <td style="padding: 5px 15px">' . $webhook?->name . '</td>
+                        </tr>
+                      </table>';
+            }
+            catch(\PayPro\Exception\ApiErrorException $e) {
                 echo sprintf(
                     '<div class="error"><p><strong>PayPro</strong> - %s</p></div>',
                     __($e->getMessage(), 'paypro-gateways-woocommerce')
@@ -50,16 +51,24 @@ class PayPro_WC_Settingspage extends WC_Settings_Page
     public function save() {
         global $current_section;
 
-        $settings = $this->get_settings();
-
-        WC_Admin_Settings::save_fields($settings);
-
         if ($current_section == 'webhook') {
-            $webhook_id = PayPro_WC_Plugin::$paypro_api->createWebhook()->id;
+            try {
+                $webhook_id = PayPro_WC_Plugin::$paypro_api->createWebhook()->id;
 
-            update_option('paypro_webhook_id', $webhook_id);
+                update_option('paypro-webhook-id', $webhook_id);
 
-            WC_Admin_Settings::add_message(__('PayPro webhook was created successfully!', 'paypro-gateways-woocommerce'));
+                WC_Admin_Settings::add_message(__('PayPro webhook was created successfully!', 'paypro-gateways-woocommerce'));
+            }
+            catch(\PayPro\Exception\ApiErrorException $e) {
+                echo sprintf(
+                    '<div class="error"><p><strong>PayPro</strong> - %s</p></div>',
+                    __($e->getMessage(), 'paypro-gateways-woocommerce')
+                );
+            }
+        } else {
+            $settings = $this->get_settings();
+
+            WC_Admin_Settings::save_fields($settings);
         }
     }
 
@@ -126,12 +135,6 @@ class PayPro_WC_Settingspage extends WC_Settings_Page
                 'title'      => __('Enable automatic cancellation', 'paypro-gateways-woocommerce'),
                 'type'       => 'checkbox',
                 'desc_tip'   => __('If a payment is cancelled automatically set the order on cancelled too.', 'paypro-gateways-woocommerce'),
-            ],
-            [
-                'id'         => $this->getSettingId('test-mode'),
-                'title'      => __('Enable test mode', 'paypro-gateways-woocommerce'),
-                'type'       => 'checkbox',
-                'desc_tip'   => __('Puts the API in test mode.', 'paypro-gateways-woocommerce'),
             ],
             [
                 'id'         => $this->getSettingId('debug-mode'),

--- a/includes/paypro/wc/settingspage.php
+++ b/includes/paypro/wc/settingspage.php
@@ -73,8 +73,7 @@ class PayPro_WC_Settingspage extends WC_Settings_Page
     }
 
     public function get_settings() {
-        global $current_section, $hide_save_button;;
-        $prefix = 'paypro_';
+        global $current_section, $hide_save_button;
 
         switch ($current_section) {
             case 'webhook':

--- a/includes/paypro/wc/settingspage.php
+++ b/includes/paypro/wc/settingspage.php
@@ -11,9 +11,80 @@ class PayPro_WC_Settingspage extends WC_Settings_Page
         parent::__construct();
     }
 
+    public function output() {
+        global $current_section, $hide_save_button;
+
+        $settings = $this->get_settings($current_section);
+
+        WC_Admin_Settings::output_fields($settings);
+
+        if ($current_section == 'webhook') {
+            $hide_save_button = true;
+
+            try {
+              $webhook_id = get_option('paypro_webhook_id', true);
+
+              $webhook = PayPro_WC_Plugin::$paypro_api->getWebhook($webhook_id);
+
+              echo '<table>
+                      <tr>
+                        <td><strong>Webhook ID</strong></td>
+                        <td style="padding: 5px 15px"><code>' . $webhook->id . '</code></td>
+                      </tr>
+                      <tr>
+                        <td><strong>Webhook Name</strong></td>
+                        <td style="padding: 5px 15px">' . $webhook->name . '</td>
+                      </tr>
+                    </table>';
+            } catch(\PayPro\Exception\ApiErrorException $e) {
+                echo sprintf(
+                    '<div class="error"><p><strong>PayPro</strong> - %s</p></div>',
+                    __($e->getMessage(), 'paypro-gateways-woocommerce')
+                );
+
+                submit_button('Create a webhook', 'secondary', 'save');
+            }
+        }
+    }
+
+    public function save() {
+        global $current_section;
+
+        $settings = $this->get_settings();
+
+        WC_Admin_Settings::save_fields($settings);
+
+        if ($current_section == 'webhook') {
+            $webhook_id = PayPro_WC_Plugin::$paypro_api->createWebhook()->id;
+
+            update_option('paypro_webhook_id', $webhook_id);
+
+            WC_Admin_Settings::add_message(__('PayPro webhook was created successfully!', 'paypro-gateways-woocommerce'));
+        }
+    }
+
+    public function get_sections() {
+        $sections = array(
+            '' => __( 'Settings', 'paypro' ),
+            'webhook' => __( 'Webhook', 'paypro' )
+        );
+
+        return apply_filters('woocommerce_get_sections_' . $this->id, $sections);
+    }
+
     public function get_settings() {
-        $settings = $this->getPayproSettings();
-        return apply_filters('woocommerce_get_settings_' . $this->id, $settings);
+        global $current_section, $hide_save_button;;
+        $prefix = 'paypro_';
+
+        switch ($current_section) {
+            case 'webhook':
+                $settings = $this->getPayproWebhook();;
+                break;
+            default:
+                $settings = $this->getPayproSettings();
+        }
+
+        return apply_filters('woocommerce_get_settings_' . $this->id, $settings, $current_section);
     }
 
     private function getPayproSettings() {
@@ -28,7 +99,7 @@ class PayPro_WC_Settingspage extends WC_Settings_Page
                 'id'         => $this->getSettingId('api-key'),
                 'title'      => __('PayPro API key', 'paypro-gateways-woocommerce'),
                 'type'       => 'text',
-                'desc_tip'   => __('API key used by the PayPro API.', 'paypro-gateways-woocommerce'), 
+                'desc_tip'   => __('API key used by the PayPro API.', 'paypro-gateways-woocommerce'),
             ],
             [
                 'id'         => $this->getSettingId('product-id'),
@@ -68,6 +139,21 @@ class PayPro_WC_Settingspage extends WC_Settings_Page
                 'title'      => __('Enable debug mode', 'paypro-gateways-woocommerce'),
                 'type'       => 'checkbox',
                 'desc_tip'   => __('Enables the PayPro plugin to output debug information to the Woocommerce logs.', 'paypro-gateways-woocommerce'),
+            ],
+            [
+                'id'         => $this->getSettingId('sectionend'),
+                'type'       => 'sectionend',
+            ]
+        ];
+    }
+
+    private function getPayproWebhook() {
+        return [
+            [
+                'id'         => $this->getSettingId('title'),
+                'type'       => 'title',
+                'title'      => __('PayPro webhook data', 'paypro-gateways-woocommerce'),
+                'desc'       => __('Webhook creation is required to use the plugin. If a webhook is created, you can see its info on this page.', 'paypro-gateways-woocommerce'),
             ],
             [
                 'id'         => $this->getSettingId('sectionend'),


### PR DESCRIPTION
The plugin needs to work with the new Webhook system. This should be possible if the merchant has entered a valid API key.

## Updates:
- Add new 'Webhook' section with 'Create webhook' button 
- This button creates a webhook in the PayPro system (only 1 webhook is allowed)
- Show webhook ID and webhook name when it is created
- The valid API key should be filled in before it is possible or give a warning

## Screenshots:
<img width="1073" alt="image" src="https://github.com/paypronl/woocommerce-payments-plugin/assets/29507358/c5e5f17f-3518-4ed1-9820-0405ee69060d">

<img width="1073" alt="image" src="https://github.com/paypronl/woocommerce-payments-plugin/assets/29507358/4d7ca4ca-f0de-4388-82bb-0e5927adaf81">

<img width="1073" alt="image" src="https://github.com/paypronl/woocommerce-payments-plugin/assets/29507358/54d08ca6-7e08-4200-907e-d15d6115a811">
