### PR TITLE
Fix incorrect calling order->cancel

### DIFF
--- a/includes/paypro/wc/webhook-handler.php
+++ b/includes/paypro/wc/webhook-handler.php
@@ -161,7 +161,7 @@ class PayPro_WC_WebhookHandler {
         }
 
         PayPro_WC_Logger::log("onWehookRequest - Order is pending and payment canceled ({$payment->id})");
-        $order->cancel($payment->id);
+        $order->cancel($payment);
     }
 
     /**


### PR DESCRIPTION
## What is the problem being solved?
We have a bug where we call the `order->cancel` incorrectly and which causes the webhook handler to fail.

## How did you solve it?
Change `$order->cancel($payment->id)` to `$order->cancel($payment)` which is the correct way.