### PR TITLE
Fix loading order issue blocks and gateways

### DIFF
--- a/includes/paypro/wc/blocks.php
+++ b/includes/paypro/wc/blocks.php
@@ -12,16 +12,15 @@ final class PayPro_WC_Blocks_Support extends AbstractPaymentMethodType {
      *
      * @var $gateway
      */
-    private $gateway;
+    private $gateway = null;
 
     /**
      * Constructor
      *
-     * @param PayPro_WC_Gateway_Abstract $gateway       Gateway to setup block support for.
+     * @param String $gateway_id ID of the gateway to use for this block.
      */
-    public function __construct($gateway) {
-        $this->gateway = $gateway;
-        $this->name    = $gateway->id;
+    public function __construct($gateway_id) {
+        $this->name = $gateway_id;
     }
 
     /**
@@ -33,7 +32,7 @@ final class PayPro_WC_Blocks_Support extends AbstractPaymentMethodType {
      * Override method to check if the block based checkout is active.
      */
     public function is_active() {
-        return $this->gateway->enabled;
+        return $this->gateway()->enabled;
     }
 
     /**
@@ -70,10 +69,26 @@ final class PayPro_WC_Blocks_Support extends AbstractPaymentMethodType {
      * Override method to pass data to the frontend.
      */
     public function get_payment_method_data() {
+        $gateway = $this->gateway();
+
         return [
-            'title'    => $this->gateway->getTitle(),
-            'iconUrl'  => $this->gateway->getIconUrl(),
-            'supports' => $this->gateway->supports,
+            'title'    => $gateway->getTitle(),
+            'iconUrl'  => $gateway->getIconUrl(),
+            'supports' => $gateway->supports,
         ];
+    }
+
+    /**
+     * Returns an instance of a gateway based on the ID provided.
+     *
+     * If a gateway has already been set we return it.
+     */
+    protected function gateway() {
+        if (null !== $this->gateway) {
+            return $this->gateway;
+        }
+
+        $this->gateway = PayPro_WC_Gateways::getGatewayById($this->name);
+        return $this->gateway;
     }
 }

--- a/includes/paypro/wc/gateways.php
+++ b/includes/paypro/wc/gateways.php
@@ -1,0 +1,85 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Gateway repository that contains all the instances of the gateways that are supported.
+ */
+class PayPro_WC_Gateways {
+    /**
+     * All available gateways.
+     *
+     * @var array $gateway_classes
+     */
+    public static $gateway_classes = [
+        'PayPro_WC_Gateway_Ideal',
+        'PayPro_WC_Gateway_Paypal',
+        'PayPro_WC_Gateway_Bancontact',
+        'PayPro_WC_Gateway_Afterpay',
+        'PayPro_WC_Gateway_BankTransfer',
+        'PayPro_WC_Gateway_Sofort',
+        'PayPro_WC_Gateway_Creditcard',
+        'PayPro_WC_Gateway_DirectDebit',
+    ];
+
+    /**
+     * Array of all the initialized gateway objects.
+     *
+     * @var array $gateways
+     */
+    private static $gateways = [];
+
+    /**
+     * Loads all the gateways from the gateway classes array.
+     */
+    public static function setupGateways() {
+        require_once __DIR__ . '/gateways/abstract.php';
+        require_once __DIR__ . '/gateways/afterpay.php';
+        require_once __DIR__ . '/gateways/bancontact.php';
+        require_once __DIR__ . '/gateways/banktransfer.php';
+        require_once __DIR__ . '/gateways/creditcard.php';
+        require_once __DIR__ . '/gateways/directdebit.php';
+        require_once __DIR__ . '/gateways/ideal.php';
+        require_once __DIR__ . '/gateways/paypal.php';
+        require_once __DIR__ . '/gateways/sofort.php';
+
+        foreach (self::$gateway_classes as $gateway_class) {
+            self::$gateways[] = new $gateway_class();
+        }
+    }
+
+    /**
+     * Get all initialized gateways
+     */
+    public static function getGateways() {
+        return self::$gateways;
+    }
+
+    /**
+     * Returns a list of all available gateway IDs
+     */
+    public static function getGatewayIds() {
+        $gateway_ids = [];
+
+        foreach (self::$gateway_classes as $gateway_class) {
+            $gateway_ids[] = strtolower($gateway_class);
+        }
+
+        return $gateway_ids;
+    }
+
+    /**
+     * Gets the instance of the gateway based on the ID
+     *
+     * @param string $gateway_id ID of the gateway.
+     */
+    public static function getGatewayById($gateway_id) {
+        foreach (self::$gateways as $gateway) {
+            if ($gateway->id === $gateway_id) {
+                return $gateway;
+            }
+        }
+
+        return null;
+    }
+}

--- a/includes/paypro/wc/plugin.php
+++ b/includes/paypro/wc/plugin.php
@@ -18,29 +18,6 @@ class PayPro_WC_Plugin {
     public static $paypro_api;
 
     /**
-     * All available gateways.
-     *
-     * @var array $gateway_classes
-     */
-    public static $gateway_classes = [
-        'PayPro_WC_Gateway_Ideal',
-        'PayPro_WC_Gateway_Paypal',
-        'PayPro_WC_Gateway_Bancontact',
-        'PayPro_WC_Gateway_Afterpay',
-        'PayPro_WC_Gateway_BankTransfer',
-        'PayPro_WC_Gateway_Sofort',
-        'PayPro_WC_Gateway_Creditcard',
-        'PayPro_WC_Gateway_DirectDebit',
-    ];
-
-    /**
-     * Array of all the initialized gateway objects.
-     *
-     * @var array $gateways
-     */
-    private static $gateways = [];
-
-    /**
      * If the plugin is initialized. Avoids double initializations.
      *
      * @var boolean $initialized
@@ -68,7 +45,7 @@ class PayPro_WC_Plugin {
         }
 
         self::setupApi();
-        self::setupGateways();
+        PayPro_WC_Gateways::setupGateways();
 
         // Add filters and actions.
         add_filter('plugin_action_links_' . PAYPRO_WC_PLUGIN_BASENAME, [ __CLASS__, 'addSettingsActionLink' ]);
@@ -102,7 +79,7 @@ class PayPro_WC_Plugin {
      * @param array $gateways Hook to register the gateways.
      */
     public static function addGateways(array $gateways) {
-        return array_merge($gateways, self::$gateways);
+        return array_merge($gateways, PayPro_WC_Gateways::getGateways());
     }
 
     /**
@@ -122,24 +99,6 @@ class PayPro_WC_Plugin {
                 <?php
             }
         );
-    }
-
-    /**
-     * Enables WooCommerce blocks support for our gateways
-     */
-    public static function setupBlockSupport() {
-        if (class_exists('Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType')) {
-            require_once 'blocks.php';
-
-            add_action(
-                'woocommerce_blocks_payment_method_type_registration',
-                function (Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry) {
-                    foreach (self::$gateways as $gateway) {
-                        $payment_method_registry->register(new PayPro_WC_Blocks_Support($gateway));
-                    }
-                }
-            );
-        }
     }
 
     /**
@@ -165,15 +124,6 @@ class PayPro_WC_Plugin {
         ];
 
         return array_merge($links, $plugin_links);
-    }
-
-    /**
-     * Loads all the gateways from the gateway classes array.
-     */
-    private static function setupGateways() {
-        foreach (self::$gateway_classes as $gateway_class) {
-            self::$gateways[] = new $gateway_class();
-        }
     }
 
     /**


### PR DESCRIPTION
## What is the problem being solved?
Our gateways use translations and thus can only be loaded after the `init`, however the `blocks` registration should happen before `init` which causes a dependency issue.

## How did you solve it?
1. Moved the loading of the blocks to the main plugin file and use the `woocommerce_blocks_loaded` action
2. Create a separate class that acts as a repository for gateway instances
3. Let the block code use the gateway ID on creation
4. Lazy load the gateway instance based on the gateway ID provided in the block.

## How can it be tested?
Make sure the payment methods show correctly on the payment page. We should also not see any messages regarding translations that are loaded too early.