### PR TITLE
Bump version to 3.2.1

### DIFF
--- a/includes/paypro/wc/plugin.php
+++ b/includes/paypro/wc/plugin.php
@@ -8,7 +8,7 @@ defined('ABSPATH') || exit;
 class PayPro_WC_Plugin {
     const PLUGIN_ID      = 'paypro-gateways-woocommerce';
     const PLUGIN_TITLE   = 'PayPro Gateways - WooCommerce';
-    const PLUGIN_VERSION = '3.2.0';
+    const PLUGIN_VERSION = '3.2.1';
 
     /**
      * The PayPro API helper class.

--- a/languages/paypro-gateways-woocommerce-nl_NL.po
+++ b/languages/paypro-gateways-woocommerce-nl_NL.po
@@ -55,7 +55,7 @@ msgstr "Een plugin voor WooCommerce die gemakkelijk alle PayPro betaalmogelijkhe
 msgid "PayPro"
 msgstr "PayPro"
 
-#: includes/paypro/wc/plugin.php:164
+#: includes/paypro/wc/plugin.php:123
 #: includes/paypro/wc/settings-page.php:139
 msgid "Settings"
 msgstr "Instellingen"
@@ -123,11 +123,11 @@ msgstr "Kan deze betaalmethode op dit moment niet gebruiken, probeer nogmaals."
 msgid "%1$s payment in process (%2$s)"
 msgstr "%1$s betaling in behandeling (%2$s)"
 
-#: includes/paypro/wc/plugin.php:185
+#: includes/paypro/wc/plugin.php:135
 msgid "API key not set. PayPro payment methods will not be displayed in the checkout process. You can find your API keys in the <a href=\"https://app.paypro.nl/developers/api-keys\" target=\"_blank\">PayPro Dashboard</a>"
 msgstr "API key niet ingevoerd. De PayPro betaalmethoden zullen niet zichtbaar zijn op de checkout pagina. Je kunt je API keys vinden in het <a href=\"https://app.paypro.nl/developers/api-keys\" target=\"_blank\">PayPro Dashboard</a>"
 
-#: includes/paypro/wc/plugin.php:200
+#: includes/paypro/wc/plugin.php:150
 msgid "API key is invalid. Make sure you supply a valid PayPro API key. You can find your API keys in the <a href=\"https://app.paypro.nl/developers/api-keys\" target=\"_blank\">PayPro Dashboard</a>"
 msgstr "API key is ongeldig. Geef een geldige PayPro API key op.  Je kunt je API keys vinden in het <a href=\"https://app.paypro.nl/developers/api-keys\" target=\"_blank\">PayPro Dashboard</a>"
 

--- a/languages/paypro-gateways-woocommerce.pot
+++ b/languages/paypro-gateways-woocommerce.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the same license as the PayPro Gateways - WooCommerce plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: PayPro Gateways - WooCommerce 3.2.0\n"
+"Project-Id-Version: PayPro Gateways - WooCommerce 3.2.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-payments-plugin\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-04T13:40:33+00:00\n"
+"POT-Creation-Date: 2025-09-24T13:48:47+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: paypro-gateways-woocommerce\n"
@@ -170,16 +170,16 @@ msgstr ""
 msgid "PayPro payment (%s) cancelled "
 msgstr ""
 
-#: includes/paypro/wc/plugin.php:164
+#: includes/paypro/wc/plugin.php:123
 #: includes/paypro/wc/settings-page.php:139
 msgid "Settings"
 msgstr ""
 
-#: includes/paypro/wc/plugin.php:185
+#: includes/paypro/wc/plugin.php:135
 msgid "API key not set. PayPro payment methods will not be displayed in the checkout process. You can find your API keys in the <a href=\"https://app.paypro.nl/developers/api-keys\" target=\"_blank\">PayPro Dashboard</a>"
 msgstr ""
 
-#: includes/paypro/wc/plugin.php:200
+#: includes/paypro/wc/plugin.php:150
 msgid "API key is invalid. Make sure you supply a valid PayPro API key. You can find your API keys in the <a href=\"https://app.paypro.nl/developers/api-keys\" target=\"_blank\">PayPro Dashboard</a>"
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "woocommerce-payments-plugin",
-  "version": "2.0.1",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "woocommerce-payments-plugin",
-      "version": "2.0.1",
+      "version": "3.2.1",
       "devDependencies": {
         "@woocommerce/dependency-extraction-webpack-plugin": "^2.3.0",
         "@wordpress/scripts": "^27.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-payments-plugin",
   "title": "PayPro Gateways WooCommerce",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "devDependencies": {
     "@woocommerce/dependency-extraction-webpack-plugin": "^2.3.0",
     "@wordpress/scripts": "^27.1.0",

--- a/paypro-gateways-woocommerce.php
+++ b/paypro-gateways-woocommerce.php
@@ -6,7 +6,7 @@ defined('ABSPATH') || exit;
  * Plugin Name: PayPro Gateways - WooCommerce
  * Plugin URI: https://www.paypro.nl/
  * Description: With this plugin you easily add all PayPro payment gateways to your WooCommerce webshop.
- * Version: 3.2.0
+ * Version: 3.2.1
  * Author: PayPro
  * Author URI: https://www.paypro.nl/
  * Requires at least: 5.0
@@ -23,7 +23,7 @@ define('PAYPRO_WC_PLUGIN_BASENAME', plugin_basename(PAYPRO_WC_PLUGIN_FILE));
 define('PAYPRO_WC_PLUGIN_PATH', plugin_dir_path(PAYPRO_WC_PLUGIN_FILE));
 define('PAYPRO_WC_PLUGIN_URL', plugin_dir_url(PAYPRO_WC_PLUGIN_FILE));
 define('PAYPRO_WC_MINIMUM_WC_VERSION', '5.0');
-define('PAYPRO_WC_VERSION', '3.2.0');
+define('PAYPRO_WC_VERSION', '3.2.1');
 
 require_once 'vendor/autoload.php';
 

--- a/resources/readme.txt
+++ b/resources/readme.txt
@@ -3,7 +3,7 @@ Contributors: paypro
 Tags: paypro, payments, gateways, woocommerce, ideal
 Requires at least: 5.0
 Tested up to: 6.8.2
-Stable tag: 3.2.0
+Stable tag: 3.2.1
 Requires PHP: 7.2
 License: GPLv2
 License URI: http://opensource.org/licenses/GPL-2.0
@@ -82,6 +82,10 @@ The Webhook is part of the new notification system the plugin uses to update the
 3. Example of the checkout payment method selection.
 
 == Changelog == 
+
+= 3.2.1 =
+
+* Fix a bug where due to incorrect loading order the payment methods would not show up during checkout
 
 = 3.2.0 =
 


### PR DESCRIPTION
## What is the problem being solved?
We would like to release a new version of the plugin. This will be version `3.2.1`

## How did you solve it?
1. Bump the version to `3.2.1`
2. Update the `readme.txt` file