### PR TITLE
Fix PayPro\Client not found  error

### DIFF
--- a/paypro-gateways-woocommerce.php
+++ b/paypro-gateways-woocommerce.php
@@ -25,7 +25,7 @@ define('PAYPRO_WC_PLUGIN_URL', plugin_dir_url(PAYPRO_WC_PLUGIN_FILE));
 define('PAYPRO_WC_MINIMUM_WC_VERSION', '5.0');
 define('PAYPRO_WC_VERSION', '3.2.2');
 
-require_once 'vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';
 
 /**
  * Entry point of the plugin.


### PR DESCRIPTION
## What is the problem being solved?
<!--- WHY is this change required? WHAT do you want to get in the result? -->
The plugin causes a Fatal Error (`Class "PayPro\Client" not found`) during updates. This happens because the plugin uses a relative path to find the autoloader. If PHP's working directory changes, it can't find the vendor folder.

## How did you solve it?
<!--- Describe your changes in detail. -->
Updated the autoloader inclusion to use an absolute path via __DIR__. This ensures the plugin always finds the vendor folder, even if the PHP working directory changes.
