### PR TITLE
Fix duplicate order processing notifications

### DIFF
--- a/includes/paypro/wc/order.php
+++ b/includes/paypro/wc/order.php
@@ -12,6 +12,13 @@ class PayPro_WC_Order {
     const MANDATE_META_DATA_KEY        = '_paypro_mandate_id';
 
     /**
+     * Seconds after which a finalization lock is considered stale and can be
+     * reclaimed. Guards against a lock never being released if a process dies
+     * mid-request.
+     */
+    const LOCK_TIMEOUT = 30;
+
+    /**
      * WooCommerce Order
      *
      * @var WC_Order $order
@@ -93,58 +100,136 @@ class PayPro_WC_Order {
     /**
      * Complete the WC order and log the results.
      *
+     * The webhook and return handlers can both reach this method for the same
+     * order at nearly the same time. A lock is used so only one of them can
+     * finalize the order, preventing duplicate status transitions (and the
+     * duplicate notification emails that come with them).
+     *
      * @param \PayPro\Entities\Payment $payment The PayPro payment object.
      */
     public function complete($payment) {
-        $status = PayPro_WC_Settings::paymentCompleteStatus();
-
-        if (empty($status)) {
-            $status = 'wc-processing';
+        if (!$this->acquireLock()) {
+            PayPro_WC_Logger::log("Order {$this->getId()} is already being finalized, skipping duplicate completion for payment ({$payment->id})");
+            return;
         }
 
-        /* translators: %s contains the payment id of the PayPro payment */
-        $message = sprintf(__('PayPro payment (%s) succeeded', 'paypro-gateways-woocommerce'), $payment->id);
-        $this->order->update_status($status, $message);
-
-        wc_reduce_stock_levels($this->getId());
-        $this->order->payment_complete();
-
-        $this->removeAllPayments();
-        $this->setActivePayment($payment);
-
-        // Update subscriptions according to payment mandate and pay method.
-        if ($this->hasSubscription()) {
-            $customer = PayPro_WC_Plugin::$paypro_api->getCustomer($payment->customer);
-            $mandate  = $customer->mandates()->first();
-
-            $this->setMandateId($mandate->id);
-
-            $subscriptions = $this->getSubscriptions();
-
-            foreach ($subscriptions as $subscription) {
-                $subscription->setMandateId($mandate->id);
-                $subscription->setCustomerId($customer->id);
+        try {
+            if (!$this->hasStatus('pending')) {
+                PayPro_WC_Logger::log("Order {$this->getId()} is no longer pending, skipping duplicate completion for payment ({$payment->id})");
+                return;
             }
+
+            $status = PayPro_WC_Settings::paymentCompleteStatus();
+
+            if (empty($status)) {
+                $status = 'wc-processing';
+            }
+
+            /* translators: %s contains the payment id of the PayPro payment */
+            $message = sprintf(__('PayPro payment (%s) succeeded', 'paypro-gateways-woocommerce'), $payment->id);
+            $this->order->update_status($status, $message);
+
+            wc_reduce_stock_levels($this->getId());
+            $this->order->payment_complete();
+
+            $this->removeAllPayments();
+            $this->setActivePayment($payment);
+
+            // Update subscriptions according to payment mandate and pay method.
+            if ($this->hasSubscription()) {
+                $customer = PayPro_WC_Plugin::$paypro_api->getCustomer($payment->customer);
+                $mandate  = $customer->mandates()->first();
+
+                $this->setMandateId($mandate->id);
+
+                $subscriptions = $this->getSubscriptions();
+
+                foreach ($subscriptions as $subscription) {
+                    $subscription->setMandateId($mandate->id);
+                    $subscription->setCustomerId($customer->id);
+                }
+            }
+        } finally {
+            $this->releaseLock();
         }
     }
 
     /**
      * Cancel the WC order and log the results.
      *
+     * Guarded by the same lock as complete() so the webhook and return
+     * handlers can't race to finalize the same order in different directions.
+     *
      * @param \PayPro\Entities\Payment $payment The PayPro payment object.
      */
     public function cancel($payment) {
-        /* translators: %s contains the payment id of the PayPro payment */
-        $message = sprintf(__('PayPro payment (%s) cancelled ', 'paypro-gateways-woocommerce'), $payment->id);
-
-        if (PayPro_WC_Settings::automaticCancellation()) {
-            WC()->cart->empty_cart();
-            $this->order->update_status('cancelled', $message);
-        } else {
-            $this->order->add_order_note($message);
+        if (!$this->acquireLock()) {
+            PayPro_WC_Logger::log("Order {$this->getId()} is already being finalized, skipping duplicate cancellation for payment ({$payment->id})");
+            return;
         }
 
-        $this->removeAllPayments();
+        try {
+            if (!$this->hasStatus('pending')) {
+                PayPro_WC_Logger::log("Order {$this->getId()} is no longer pending, skipping duplicate cancellation for payment ({$payment->id})");
+                return;
+            }
+
+            /* translators: %s contains the payment id of the PayPro payment */
+            $message = sprintf(__('PayPro payment (%s) cancelled ', 'paypro-gateways-woocommerce'), $payment->id);
+
+            if (PayPro_WC_Settings::automaticCancellation()) {
+                WC()->cart->empty_cart();
+                $this->order->update_status('cancelled', $message);
+            } else {
+                $this->order->add_order_note($message);
+            }
+
+            $this->removeAllPayments();
+        } finally {
+            $this->releaseLock();
+        }
+    }
+
+    /**
+     * Attempts to atomically claim this order for finalization.
+     *
+     * Relies on the unique key on wp_options.option_name to make the claim
+     * atomic across concurrent requests/processes, which a non-persistent
+     * object cache cannot guarantee.
+     *
+     * @return bool True if the lock was acquired.
+     */
+    private function acquireLock() {
+        $lock_key = $this->getLockKey();
+        $now      = time();
+
+        if (add_option($lock_key, $now, '', 'no')) {
+            return true;
+        }
+
+        $locked_at = get_option($lock_key);
+
+        // Reclaim a lock left behind by a process that never released it.
+        if ($locked_at && ($now - (int) $locked_at) > self::LOCK_TIMEOUT) {
+            return update_option($lock_key, $now, 'no');
+        }
+
+        return false;
+    }
+
+    /**
+     * Releases the lock acquired via acquireLock().
+     */
+    private function releaseLock() {
+        delete_option($this->getLockKey());
+    }
+
+    /**
+     * Returns the option name used to lock this order against concurrent
+     * finalization.
+     */
+    private function getLockKey() {
+        return '_paypro_order_lock_' . $this->getId();
     }
 
     /**

--- a/includes/paypro/wc/order.php
+++ b/includes/paypro/wc/order.php
@@ -214,11 +214,12 @@ class PayPro_WC_Order {
     }
 
     /**
-     * Returns the option name used to lock this order against concurrent
-     * finalization.
+     * Returns the lock name used to lock this order against concurrent
+     * finalization. Includes the DB name since GET_LOCK() is scoped to the
+     * whole MySQL server, not per database.
      */
     private function getLockKey() {
-        return '_paypro_order_lock_' . $this->getId();
+        return '_paypro_lock_' . md5(DB_NAME . '_' . $this->getId());
     }
 
     /**

--- a/includes/paypro/wc/order.php
+++ b/includes/paypro/wc/order.php
@@ -12,13 +12,6 @@ class PayPro_WC_Order {
     const MANDATE_META_DATA_KEY        = '_paypro_mandate_id';
 
     /**
-     * Seconds after which a finalization lock is considered stale and can be
-     * reclaimed. Guards against a lock never being released if a process dies
-     * mid-request.
-     */
-    const LOCK_TIMEOUT = 30;
-
-    /**
      * WooCommerce Order
      *
      * @var WC_Order $order
@@ -193,35 +186,31 @@ class PayPro_WC_Order {
     /**
      * Attempts to atomically claim this order for finalization.
      *
-     * Relies on the unique key on wp_options.option_name to make the claim
-     * atomic across concurrent requests/processes, which a non-persistent
-     * object cache cannot guarantee.
+     * Uses a MySQL named lock (GET_LOCK), which is exclusive and scoped to
+     * the DB connection, so it can't be granted to two concurrent
+     * requests/processes at once. It's also automatically released if the
+     * holding connection dies, so a crashed process can't leave the order
+     * locked forever.
      *
      * @return bool True if the lock was acquired.
      */
     private function acquireLock() {
-        $lock_key = $this->getLockKey();
-        $now      = time();
+        global $wpdb;
 
-        if (add_option($lock_key, $now, '', 'no')) {
-            return true;
-        }
+        $acquired = $wpdb->get_var(
+            $wpdb->prepare('SELECT GET_LOCK(%s, 0)', $this->getLockKey())
+        );
 
-        $locked_at = get_option($lock_key);
-
-        // Reclaim a lock left behind by a process that never released it.
-        if ($locked_at && ( $now - (int) $locked_at ) > self::LOCK_TIMEOUT) {
-            return update_option($lock_key, $now, 'no');
-        }
-
-        return false;
+        return '1' === $acquired;
     }
 
     /**
      * Releases the lock acquired via acquireLock().
      */
     private function releaseLock() {
-        delete_option($this->getLockKey());
+        global $wpdb;
+
+        $wpdb->query($wpdb->prepare('SELECT RELEASE_LOCK(%s)', $this->getLockKey()));
     }
 
     /**

--- a/includes/paypro/wc/order.php
+++ b/includes/paypro/wc/order.php
@@ -210,7 +210,7 @@ class PayPro_WC_Order {
         $locked_at = get_option($lock_key);
 
         // Reclaim a lock left behind by a process that never released it.
-        if ($locked_at && ($now - (int) $locked_at) > self::LOCK_TIMEOUT) {
+        if ($locked_at && ( $now - (int) $locked_at ) > self::LOCK_TIMEOUT) {
             return update_option($lock_key, $now, 'no');
         }
 


### PR DESCRIPTION
## What is the problem being solved?

Merchants were getting duplicate order processing notifications. The webhook (from PayPro) and the return handler (customer redirect) can both try to finish the same order. Both check `hasStatus('pending')` before calling `complete()`/`cancel()`, so if they arrive close together, both can see `pending` before either saves a change — and both finish the order.

## How did you solve it?

Added a lock in `PayPro_WC_Order` (`includes/paypro/wc/order.php`) so only one process can finish a given order.

`acquireLock()`/`releaseLock()` use MySQL's `GET_LOCK()`/`RELEASE_LOCK()` — an exclusive, connection-scoped advisory lock. Only one session can hold a given lock name at a time; others get rejected immediately. It's also released automatically if the holding process dies, so no stale-lock handling is needed.

`complete()`/`cancel()` acquire the lock first; if another process holds it, they log and stop. Once locked, they re-check `hasStatus('pending')` before doing anything, closing the race. The lock is always released in a `finally` block.

## How can it be tested?

- Fire the webhook and return-URL request for the same order at nearly the same time; confirm the order is finalized exactly once and only one email is sent.
- Kill a worker mid-`complete()`; confirm a later request can still finalize the order.

## Screenshots:

N/A