### PR TITLE
Prevent fatal error when plugin files fail to load

### DIFF
--- a/paypro-gateways-woocommerce.php
+++ b/paypro-gateways-woocommerce.php
@@ -26,13 +26,33 @@ define('PAYPRO_WC_MINIMUM_WC_VERSION', '5.0');
 define('PAYPRO_WC_VERSION', '3.2.2');
 
 /**
+ * Requires a file, throwing an exception instead of a fatal error if it's missing.
+ *
+ * @param string $file Absolute path of the file to require.
+ */
+function paypro_wc_require_or_fail($file) {
+    if (!file_exists($file)) {
+        throw new \Exception("Required file not found: {$file}");
+    }
+
+    require_once $file;
+}
+
+/**
  * Logs a failure to load the plugin's files and shows an admin notice, instead of letting
  * the site crash with an uncaught fatal error.
  *
  * @param \Throwable $e The error or exception that was caught.
  */
 function paypro_wc_handle_load_failure($e) {
+    static $notified = false;
+
     error_log('PayPro Gateways - WooCommerce failed to load: ' . $e->getMessage());
+
+    if ($notified) {
+        return;
+    }
+    $notified = true;
 
     add_action(
         'admin_notices',
@@ -51,7 +71,7 @@ function paypro_wc_handle_load_failure($e) {
 }
 
 try {
-    require_once __DIR__ . '/vendor/autoload.php';
+    paypro_wc_require_or_fail(__DIR__ . '/vendor/autoload.php');
 } catch (\Throwable $e) {
     paypro_wc_handle_load_failure($e);
     return;
@@ -72,16 +92,16 @@ function paypro_plugin_init() {
     if (in_array('woocommerce/woocommerce.php', $active_plugins, true) || class_exists('WooCommerce')) {
         try {
             // blocks.php, settings-page.php, gateways.php and all gateways are loaded seperately.
-            require_once __DIR__ . '/includes/paypro/wc/api.php';
-            require_once __DIR__ . '/includes/paypro/wc/helper.php';
-            require_once __DIR__ . '/includes/paypro/wc/gateways.php';
-            require_once __DIR__ . '/includes/paypro/wc/logger.php';
-            require_once __DIR__ . '/includes/paypro/wc/order.php';
-            require_once __DIR__ . '/includes/paypro/wc/payment-handler.php';
-            require_once __DIR__ . '/includes/paypro/wc/plugin.php';
-            require_once __DIR__ . '/includes/paypro/wc/settings.php';
-            require_once __DIR__ . '/includes/paypro/wc/subscription.php';
-            require_once __DIR__ . '/includes/paypro/wc/webhook-handler.php';
+            paypro_wc_require_or_fail(__DIR__ . '/includes/paypro/wc/api.php');
+            paypro_wc_require_or_fail(__DIR__ . '/includes/paypro/wc/helper.php');
+            paypro_wc_require_or_fail(__DIR__ . '/includes/paypro/wc/gateways.php');
+            paypro_wc_require_or_fail(__DIR__ . '/includes/paypro/wc/logger.php');
+            paypro_wc_require_or_fail(__DIR__ . '/includes/paypro/wc/order.php');
+            paypro_wc_require_or_fail(__DIR__ . '/includes/paypro/wc/payment-handler.php');
+            paypro_wc_require_or_fail(__DIR__ . '/includes/paypro/wc/plugin.php');
+            paypro_wc_require_or_fail(__DIR__ . '/includes/paypro/wc/settings.php');
+            paypro_wc_require_or_fail(__DIR__ . '/includes/paypro/wc/subscription.php');
+            paypro_wc_require_or_fail(__DIR__ . '/includes/paypro/wc/webhook-handler.php');
 
             PayPro_WC_Plugin::init();
         } catch (\Throwable $e) {
@@ -166,8 +186,8 @@ add_action('init', 'paypro_plugin_init');
 add_action('woocommerce_blocks_loaded', function() {
     if (class_exists('Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType')) {
         try {
-            require_once __DIR__ . '/includes/paypro/wc/blocks.php';
-            require_once __DIR__ . '/includes/paypro/wc/gateways.php';
+            paypro_wc_require_or_fail(__DIR__ . '/includes/paypro/wc/blocks.php');
+            paypro_wc_require_or_fail(__DIR__ . '/includes/paypro/wc/gateways.php');
 
             add_action(
                 'woocommerce_blocks_payment_method_type_registration',

--- a/paypro-gateways-woocommerce.php
+++ b/paypro-gateways-woocommerce.php
@@ -25,7 +25,37 @@ define('PAYPRO_WC_PLUGIN_URL', plugin_dir_url(PAYPRO_WC_PLUGIN_FILE));
 define('PAYPRO_WC_MINIMUM_WC_VERSION', '5.0');
 define('PAYPRO_WC_VERSION', '3.2.2');
 
-require_once __DIR__ . '/vendor/autoload.php';
+/**
+ * Logs a failure to load the plugin's files and shows an admin notice, instead of letting
+ * the site crash with an uncaught fatal error.
+ *
+ * @param \Throwable $e The error or exception that was caught.
+ */
+function paypro_wc_handle_load_failure($e) {
+    error_log('PayPro Gateways - WooCommerce failed to load: ' . $e->getMessage());
+
+    add_action(
+        'admin_notices',
+        function () use ($e) {
+            ?>
+            <div class="notice notice-error">
+                <p>
+                    <strong>PayPro Gateways - WooCommerce</strong> failed to load correctly and has been disabled for this request.
+                    Please try reinstalling the plugin. If the problem persists, contact PayPro support.<br />
+                    Details: <?php echo esc_html($e->getMessage()); ?>
+                </p>
+            </div>
+            <?php
+        }
+    );
+}
+
+try {
+    require_once __DIR__ . '/vendor/autoload.php';
+} catch (\Throwable $e) {
+    paypro_wc_handle_load_failure($e);
+    return;
+}
 
 /**
  * Entry point of the plugin.
@@ -40,19 +70,23 @@ function paypro_plugin_init() {
     $active_plugins = apply_filters('active_plugins', get_option('active_plugins'));
 
     if (in_array('woocommerce/woocommerce.php', $active_plugins, true) || class_exists('WooCommerce')) {
-        // blocks.php, settings-page.php, gateways.php and all gateways are loaded seperately.
-        require_once __DIR__ . '/includes/paypro/wc/api.php';
-        require_once __DIR__ . '/includes/paypro/wc/helper.php';
-        require_once __DIR__ . '/includes/paypro/wc/gateways.php';
-        require_once __DIR__ . '/includes/paypro/wc/logger.php';
-        require_once __DIR__ . '/includes/paypro/wc/order.php';
-        require_once __DIR__ . '/includes/paypro/wc/payment-handler.php';
-        require_once __DIR__ . '/includes/paypro/wc/plugin.php';
-        require_once __DIR__ . '/includes/paypro/wc/settings.php';
-        require_once __DIR__ . '/includes/paypro/wc/subscription.php';
-        require_once __DIR__ . '/includes/paypro/wc/webhook-handler.php';
+        try {
+            // blocks.php, settings-page.php, gateways.php and all gateways are loaded seperately.
+            require_once __DIR__ . '/includes/paypro/wc/api.php';
+            require_once __DIR__ . '/includes/paypro/wc/helper.php';
+            require_once __DIR__ . '/includes/paypro/wc/gateways.php';
+            require_once __DIR__ . '/includes/paypro/wc/logger.php';
+            require_once __DIR__ . '/includes/paypro/wc/order.php';
+            require_once __DIR__ . '/includes/paypro/wc/payment-handler.php';
+            require_once __DIR__ . '/includes/paypro/wc/plugin.php';
+            require_once __DIR__ . '/includes/paypro/wc/settings.php';
+            require_once __DIR__ . '/includes/paypro/wc/subscription.php';
+            require_once __DIR__ . '/includes/paypro/wc/webhook-handler.php';
 
-        PayPro_WC_Plugin::init();
+            PayPro_WC_Plugin::init();
+        } catch (\Throwable $e) {
+            paypro_wc_handle_load_failure($e);
+        }
     }
 }
 
@@ -131,17 +165,21 @@ add_action('init', 'paypro_plugin_init');
 // We need to load this before the 'init' action and therefore cannot have it in the main plugin file.
 add_action('woocommerce_blocks_loaded', function() {
     if (class_exists('Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType')) {
-        require_once __DIR__ . '/includes/paypro/wc/blocks.php';
-        require_once __DIR__ . '/includes/paypro/wc/gateways.php';
+        try {
+            require_once __DIR__ . '/includes/paypro/wc/blocks.php';
+            require_once __DIR__ . '/includes/paypro/wc/gateways.php';
 
-        add_action(
-            'woocommerce_blocks_payment_method_type_registration',
-            function (Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry) {
-                foreach (PayPro_WC_Gateways::getGatewayIds() as $gateway_id) {
-                    $payment_method_registry->register(new PayPro_WC_Blocks_Support($gateway_id));
+            add_action(
+                'woocommerce_blocks_payment_method_type_registration',
+                function (Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry) {
+                    foreach (PayPro_WC_Gateways::getGatewayIds() as $gateway_id) {
+                        $payment_method_registry->register(new PayPro_WC_Blocks_Support($gateway_id));
+                    }
                 }
-            }
-        );
+            );
+        } catch (\Throwable $e) {
+            paypro_wc_handle_load_failure($e);
+        }
     }
 });
 


### PR DESCRIPTION
## What is the problem being solved?
<!--- WHY is this change required? WHAT do you want to get in the result? -->
A merchant hit a fatal, site-wide crash: `Uncaught Error: Failed opening required '.../includes/paypro/wc/webhook-handler.php'`. This happens because `paypro_plugin_init()` runs on the `init` hook (every request, including `wp-admin`) and does a bare `require_once` for each of the plugin's files. If any single file is missing or unreadable at request time — e.g. removed by a host-level security scanner, or caught mid-update — PHP throws an uncaught `Error` and takes down the entire site, not just PayPro. This also blocked `wp-admin`, so the merchant couldn't even disable the plugin to recover. 

## How did you solve it?
<!--- Describe your changes in detail. -->
Wrapped each of the three `require_once` chains in `try/catch (\Throwable $e)`, with a shared helper `paypro_wc_handle_load_failure()` that logs the error and shows an admin notice instead of letting the site crash. 

## How can it be tested?
<!--- Please describe in detail how to test your changes. -->
1. `mv includes/paypro/wc/webhook-handler.php includes/paypro/wc/webhook-handler.php.bak`
2. Load any page with WooCommerce + PayPro active --> before: fatal/white screen; after: page loads with an admin notice and the error logged.
3. Restore the file and confirm the notice disappears and PayPro initializes normally.